### PR TITLE
Made error message more informative.

### DIFF
--- a/pkg/api/type.go
+++ b/pkg/api/type.go
@@ -65,3 +65,9 @@ type Link struct {
 }
 
 type List struct{}
+
+type APIErrorDTO struct {
+	ResponseType int    `json:"type"`
+	Exception    string `json:"exception,omitempty"`
+	Message      string `json:"message"`
+}

--- a/pkg/client/parser.go
+++ b/pkg/client/parser.go
@@ -1,0 +1,17 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/turbonomic/turbo-api/pkg/api"
+)
+
+func parseAPIErrorDTO(errorMessage string) (*api.APIErrorDTO, error) {
+	var dto api.APIErrorDTO
+	err := json.Unmarshal([]byte(errorMessage), &dto)
+	if err != nil {
+		return nil, fmt.Errorf("Unmarshall error: %s", err)
+	}
+	return &dto, nil
+}

--- a/pkg/client/parser_test.go
+++ b/pkg/client/parser_test.go
@@ -1,0 +1,55 @@
+package client
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/turbonomic/turbo-api/pkg/api"
+)
+
+func TestParseAPIErrorDTO(t *testing.T) {
+	table := []struct {
+		responseType int
+		exception    string
+		message      string
+
+		expectsErr bool
+	}{
+		{
+			responseType: 400,
+			exception:    "internal exception",
+			message:      "error happend",
+
+			expectsErr: false,
+		},
+	}
+
+	for _, item := range table {
+		input := fmt.Sprintf("{\"type\": %d, \"exception\":\"%s\", \"message\":\"%s\"}", item.responseType,
+			item.exception, item.message)
+		errDTO, err := parseAPIErrorDTO(input)
+		if err != nil {
+			if !item.expectsErr {
+				t.Errorf("Unexpected error %s", err)
+			}
+		} else {
+			expectedErrorDTO := &api.APIErrorDTO{
+				ResponseType: item.responseType,
+				Exception:    item.exception,
+				Message:      item.message,
+			}
+			if !reflect.DeepEqual(expectedErrorDTO, errDTO) {
+				t.Errorf("Expected %v, got %v", expectedErrorDTO, errDTO)
+			}
+		}
+	}
+}
+
+func TestParseAPIErrorDTOUnMarshallError(t *testing.T) {
+	input := "invalid content"
+	_, err := parseAPIErrorDTO(input)
+	if err == nil {
+		t.Error("Expected UnMarshalling error, got not error.")
+	}
+}

--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -177,7 +177,6 @@ func (r *Request) request(fn func(*http.Response)) error {
 
 	url := r.URL().String()
 	glog.V(4).Infof("The request url is %s", url)
-	fmt.Printf("The request url is %s\n", url)
 	req, err := http.NewRequest(r.verb, url, r.data)
 	if err != nil {
 		return err

--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 
 	"github.com/turbonomic/turbo-api/pkg/api"
-
-	"github.com/golang/glog"
 )
 
 type HTTPClient interface {
@@ -175,9 +173,8 @@ func (r *Request) request(fn func(*http.Response)) error {
 		return r.err
 	}
 
-	url := r.URL().String()
-	glog.V(4).Infof("The request url is %s", url)
-	req, err := http.NewRequest(r.verb, url, r.data)
+	requestURL := r.URL().String()
+	req, err := http.NewRequest(r.verb, requestURL, r.data)
 	if err != nil {
 		return err
 	}
@@ -211,7 +208,7 @@ func parseHTTPResponse(resp *http.Response) Result {
 	content, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return Result{
-			err: fmt.Errorf("Error reading response body:%++v", err),
+			err: fmt.Errorf("Error reading response body: %++v", err),
 		}
 	}
 


### PR DESCRIPTION
Before change, in the error message we only know the status and status code of a failed API call.
Now we parse the error message in the response body into APIErrorDTOs, which contains status, exception and message. So that we can append message part to the error message to have it contain more information about why an API request failed.