### PR TITLE
Add proxy support for rest client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.9
+  - 1.14
   - tip
 
 go_import_path: github.com/turbonomic/turbo-api

--- a/pkg/client/api_client.go
+++ b/pkg/client/api_client.go
@@ -41,16 +41,22 @@ func NewAPIClientWithBA(c *Config) (*Client, error) {
 			//Non-Aunthenticated proxy format: http://ip:port
 			if strings.Index(proxy, "@") != -1 {
 				//Extract the username password portion, with @
-				usernamePassword := proxy[strings.Index(proxy, "//")+2 : strings.Index(proxy, "@")+1]
+				usernamePassword := proxy[strings.Index(proxy, "//")+2 : strings.LastIndex(proxy, "@")+1]
 				username := usernamePassword[:strings.Index(usernamePassword, ":")]
-				password := usernamePassword[strings.Index(usernamePassword, ":")+1 : strings.Index(usernamePassword, "@")]
+				password := usernamePassword[strings.Index(usernamePassword, ":")+1 : strings.LastIndex(usernamePassword, "@")]
 				//Extract Proxy address by remove the username_password
 				proxyAddr := strings.ReplaceAll(proxy, usernamePassword, "")
-				proxyURL, _ := url.Parse(proxyAddr)
+				proxyURL, err := url.Parse(proxyAddr)
+				if err != nil {
+					return nil,  fmt.Errorf("Failed to parse proxy\n")
+				}
 				proxyURL.User = url.UserPassword(username, password)
 				tr.Proxy = http.ProxyURL(proxyURL)
 			} else {
-				proxyURL, _ := url.Parse(proxy)
+				proxyURL, err := url.Parse(proxy)
+				if err != nil {
+					return nil,  fmt.Errorf("Failed to parse proxy\n")
+				}
 				tr.Proxy = http.ProxyURL(proxyURL)
 			}
 		}

--- a/pkg/client/api_client.go
+++ b/pkg/client/api_client.go
@@ -48,14 +48,14 @@ func NewAPIClientWithBA(c *Config) (*Client, error) {
 				proxyAddr := strings.ReplaceAll(proxy, usernamePassword, "")
 				proxyURL, err := url.Parse(proxyAddr)
 				if err != nil {
-					return nil,  fmt.Errorf("Failed to parse proxy\n")
+					return nil, fmt.Errorf("Failed to parse proxy\n")
 				}
 				proxyURL.User = url.UserPassword(username, password)
 				tr.Proxy = http.ProxyURL(proxyURL)
 			} else {
 				proxyURL, err := url.Parse(proxy)
 				if err != nil {
-					return nil,  fmt.Errorf("Failed to parse proxy\n")
+					return nil, fmt.Errorf("Failed to parse proxy\n")
 				}
 				tr.Proxy = http.ProxyURL(proxyURL)
 			}

--- a/pkg/client/api_client.go
+++ b/pkg/client/api_client.go
@@ -40,12 +40,12 @@ func NewAPIClientWithBA(c *Config) (*Client, error) {
 		//Non-Aunthenticated proxy format: http://ip:port
 		if strings.Index(proxy, "@") != -1 {
 			//Extract the username password portion, with @
-			username_password := proxy[strings.Index(proxy, "//")+2 : strings.Index(proxy, "@")+1]
-			username := username_password[:strings.Index(username_password, ":")]
-			password := username_password[strings.Index(username_password, ":")+1 : strings.Index(username_password, "@")]
+			usernamePassword := proxy[strings.Index(proxy, "//")+2 : strings.Index(proxy, "@")+1]
+			username := usernamePassword[:strings.Index(usernamePassword, ":")]
+			password := usernamePassword[strings.Index(usernamePassword, ":")+1 : strings.Index(usernamePassword, "@")]
 			//Extract Proxy address by remove the username_password
-			proxy_addr := strings.ReplaceAll(proxy, username_password, "")
-			proxyURL, _ := url.Parse(proxy_addr)
+			proxyAddr := strings.ReplaceAll(proxy, usernamePassword, "")
+			proxyURL, _ := url.Parse(proxyAddr)
 			proxyURL.User = url.UserPassword(username, password)
 			tr.Proxy = http.ProxyURL(proxyURL)
 		} else {

--- a/pkg/client/api_client_test.go
+++ b/pkg/client/api_client_test.go
@@ -22,11 +22,11 @@ func TestNewAPIClientWithBA(t *testing.T) {
 		expectsError   bool
 	}{
 		{
-			config:       &Config{baseURL, apiPath, nil},
+			config:       &Config{baseURL, apiPath, nil, ""},
 			expectsError: true,
 		},
 		{
-			config: &Config{baseURL, apiPath, &BasicAuthentication{"foo", "bar"}},
+			config: &Config{baseURL, apiPath, &BasicAuthentication{"foo", "bar"}, ""},
 			expectedClient: &Client{
 				&RESTClient{http.DefaultClient, baseURL, apiPath, &BasicAuthentication{"foo", "bar"}},
 				nil,
@@ -34,7 +34,7 @@ func TestNewAPIClientWithBA(t *testing.T) {
 			expectsError: false,
 		},
 		{
-			config: &Config{secureURL, apiPath, &BasicAuthentication{"foo", "bar"}},
+			config: &Config{secureURL, apiPath, &BasicAuthentication{"foo", "bar"}, ""},
 			expectedClient: &Client{
 				&RESTClient{&http.Client{Transport: &http.Transport{
 					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
@@ -60,7 +60,7 @@ func TestClient_DiscoverTarget_WithError(t *testing.T) {
 	address := ""
 	baseURL, _ := url.Parse("http://localhost")
 	apiPath := "path/to/api"
-	config := &Config{baseURL, apiPath, &BasicAuthentication{"foo", "bar"}}
+	config := &Config{baseURL, apiPath, &BasicAuthentication{"foo", "bar"}, ""}
 	client, _ := NewAPIClientWithBA(config)
 	_, err := client.DiscoverTarget(address)
 	if err == nil {
@@ -72,7 +72,7 @@ func TestClient_AddTarget_WithError(t *testing.T) {
 	target := &api.Target{}
 	baseURL, _ := url.Parse("http://localhost")
 	apiPath := "path/to/api"
-	config := &Config{baseURL, apiPath, &BasicAuthentication{"foo", "bar"}}
+	config := &Config{baseURL, apiPath, &BasicAuthentication{"foo", "bar"}, ""}
 	client, _ := NewAPIClientWithBA(config)
 	_, err := client.AddTarget(target)
 	if err == nil {

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -62,6 +62,6 @@ func (cb *ConfigBuilder) Create() *Config {
 			return cb.apiPath
 		}(),
 		basicAuth: cb.basicAuth,
-		proxy: cb.proxy,
+		proxy:     cb.proxy,
 	}
 }

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -16,12 +16,15 @@ type Config struct {
 
 	// For Basic authentication.
 	basicAuth *BasicAuthentication
+	// For proxy
+	proxy string
 }
 
 type ConfigBuilder struct {
 	serverAddress *url.URL
 	apiPath       string
 	basicAuth     *BasicAuthentication
+	proxy         string
 }
 
 func NewConfigBuilder(serverAddress *url.URL) *ConfigBuilder {
@@ -32,6 +35,11 @@ func NewConfigBuilder(serverAddress *url.URL) *ConfigBuilder {
 
 func (cb *ConfigBuilder) APIPath(apiPath string) *ConfigBuilder {
 	cb.apiPath = apiPath
+	return cb
+}
+
+func (cb *ConfigBuilder) SetProxy(proxy string) *ConfigBuilder {
+	cb.proxy = proxy
 	return cb
 }
 
@@ -54,5 +62,6 @@ func (cb *ConfigBuilder) Create() *Config {
 			return cb.apiPath
 		}(),
 		basicAuth: cb.basicAuth,
+		proxy: cb.proxy,
 	}
 }

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -65,11 +65,11 @@ func TestConfigBuilder_Create(t *testing.T) {
 			apiPath:        "path/to/api",
 			username:       "foo",
 			password:       "bar",
-			expectedConfig: &Config{baseURL, "path/to/api", &BasicAuthentication{"foo", "bar"}},
+			expectedConfig: &Config{baseURL, "path/to/api", &BasicAuthentication{"foo", "bar"}, ""},
 		},
 		{
 			serverAddress:  baseURL,
-			expectedConfig: &Config{baseURL, defaultAPIPath, nil},
+			expectedConfig: &Config{baseURL, defaultAPIPath, nil, ""},
 		},
 	}
 	for _, item := range table {


### PR DESCRIPTION
The proxy will be fed through the configmap in kubeturbo.
Depends on the proxy server requires authentication or not,
Authenticated proxy format: http://username:password@ip:port
Non-Aunthenticated proxy format: http://ip:port