### PR TITLE
Fix target update error

### DIFF
--- a/pkg/api/type.go
+++ b/pkg/api/type.go
@@ -43,6 +43,8 @@ type TargetSpec struct {
 	DerivedTargetIDs []string `json:"derivedTargetIds"`
 	// Account values to use to add the target
 	InputFields []*InputField `json:"inputFields,omitempty"`
+	// The communication channel of a target
+	CommunicationBindingChannel string `json:"communicationBindingChannel,omitempty"`
 }
 
 // ProbeDescription defines the protocols of the GET /probe topology-processor service

--- a/pkg/client/tp_client.go
+++ b/pkg/client/tp_client.go
@@ -190,7 +190,9 @@ func (c *TPClient) getProbeID(probeType, probeCategory string) (int64, error) {
 }
 
 func (c *TPClient) updateTarget(existingTarget *api.TargetInfo, input *api.Target) error {
-	inputFieldsData, err := json.Marshal(input.InputFields)
+	// existingTarget.TargetSpec is guaranteed to be non nil
+	existingTarget.TargetSpec.InputFields = input.InputFields
+	targetData, err := json.Marshal(existingTarget.TargetSpec)
 	if err != nil {
 		return fmt.Errorf("failed to marshall input fields array: %v", err)
 	}
@@ -198,10 +200,10 @@ func (c *TPClient) updateTarget(existingTarget *api.TargetInfo, input *api.Targe
 	request := c.Put().Resource(api.Resource_Type_Target).Name(strconv.FormatInt(existingTarget.TargetID, 10)).
 		Header("Content-Type", "application/json").
 		Header("Accept", "application/json").
-		Data(inputFieldsData)
+		Data(targetData)
 
 	glog.V(4).Infof("[UpdateTarget] %v", request)
-	glog.V(4).Infof("[UpdateTarget] Data: %s", inputFieldsData)
+	glog.V(4).Infof("[UpdateTarget] Data: %s", targetData)
 
 	// Execute the request
 	response, err := request.Do()


### PR DESCRIPTION
In https://vmturbo.atlassian.net/browse/OM-65174 we changed the request body of TP target update API. This causes `kubeturbo` to fail to update existing target.

This fix modifies the request body of TP `PUT /target` call. 

Tested with latest 8.0.6 XL build, and verified adding/updating targets through either API or TP.