### PR TITLE
Added support of communication binding channel

### DIFF
--- a/pkg/api/type.go
+++ b/pkg/api/type.go
@@ -1,7 +1,7 @@
 package api
 
-// COMMUNICATION_BINDING_CHANNEL is an InputField name indicating the field value is the communication binding channel
-const COMMUNICATION_BINDING_CHANNEL = "communicationBindingChannel"
+// CommunicationBindingChannel is an InputField name indicating the field value is the communication binding channel
+const CommunicationBindingChannel = "communicationBindingChannel"
 
 type Target struct {
 	// Category of a probe, i.e. Hypervisor, Storage and so on.

--- a/pkg/api/type.go
+++ b/pkg/api/type.go
@@ -1,5 +1,8 @@
 package api
 
+// COMMUNICATION_BINDING_CHANNEL is an InputField name indicating the field value is the communication binding channel
+const COMMUNICATION_BINDING_CHANNEL = "communicationBindingChannel"
+
 type Target struct {
 	// Category of a probe, i.e. Hypervisor, Storage and so on.
 	Category    string `json:"category,omitempty"`

--- a/pkg/client/api_client.go
+++ b/pkg/client/api_client.go
@@ -53,7 +53,7 @@ func (c *APIClient) AddTarget(target *api.Target) error {
 			"(old probe type: %v, new probe type: %v, old target: %v, new target: %v)",
 			existingTarget.Type, target.Type, existingTarget, target)
 		if err := c.deleteTarget(existingTarget); err != nil {
-			return fmt.Errorf("failed to delete target %v of type %v which is necessary due to probe type changed" +
+			return fmt.Errorf("failed to delete target %v of type %v which is necessary due to probe type changed"+
 				" to %v; error: %v", existingTarget.DisplayName, existingTarget.Type, target.Type, err)
 		}
 	}

--- a/pkg/client/api_client.go
+++ b/pkg/client/api_client.go
@@ -6,6 +6,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/turbonomic/turbo-api/pkg/api"
 	"net/http"
+	"strings"
 )
 
 // APIClient connects to api service through ingress
@@ -45,7 +46,16 @@ func (c *APIClient) AddTarget(target *api.Target) error {
 	// Update the target if it already exists
 	if existingTarget != nil {
 		glog.V(2).Infof("Target %v already exists.", getTargetId(target))
-		return c.updateTarget(existingTarget, target)
+		if target.Type == existingTarget.Type {
+			return c.updateTarget(existingTarget, target)
+		}
+		glog.V(2).Infof("Delete and re-add the target since the probe type has changed "+
+			"(old probe type: %v, new probe type: %v, old target: %v, new target: %v)",
+			existingTarget.Type, target.Type, existingTarget, target)
+		if err := c.deleteTarget(existingTarget); err != nil {
+			return fmt.Errorf("failed to delete target %v of type %v which is necessary due to probe type changed" +
+				" to %v; error: %v", existingTarget.DisplayName, existingTarget.Type, target.Type, err)
+		}
 	}
 	// Construct the Target required by the rest api
 	targetData, err := json.Marshal(target)
@@ -147,13 +157,14 @@ func (c *APIClient) findTarget(target *api.Target) (*api.Target, error) {
 
 	// Iterate over the list of targets to look for the given target
 	// by comparing the category, target type and identifier fields
+	// target type is regarded the same if the old one only differs by an extra suffix
 	for _, tgt := range targetList {
 		// array of InputFields
 		for _, inputField := range tgt.InputFields {
 			if inputField.Name == "targetIdentifier" &&
 				inputField.Value == targetId &&
 				tgt.Category == target.Category &&
-				tgt.Type == target.Type {
+				strings.HasPrefix(tgt.Type, target.Type) {
 				return &tgt, nil
 			}
 		}
@@ -193,5 +204,31 @@ func (c *APIClient) updateTarget(existing, input *api.Target) error {
 	}
 
 	glog.V(2).Infof("Successfully updated target via API service.")
+	return nil
+}
+
+// deleteTarget deletes an existing target
+func (c *APIClient) deleteTarget(existing *api.Target) error {
+	// Create the rest api request
+	request := c.Delete().Resource(api.Resource_Type_Targets).Name(existing.UUID).
+		Header("Content-Type", "application/json").
+		Header("Accept", "application/json").
+		Header("Cookie", fmt.Sprintf("%s=%s", c.SessionCookie.Name, c.SessionCookie.Value))
+
+	glog.V(4).Infof("[DeleteTarget] %v.", request)
+
+	// Execute the request
+	response, err := request.Do()
+	if err != nil {
+		return fmt.Errorf("request %v failed: %s", request, err)
+	}
+	glog.V(4).Infof("Response %+v.", response)
+
+	if response.statusCode != 200 {
+		return buildResponseError("target delete", response.status, response.body)
+	}
+
+	glog.V(2).Infof("Successfully deleted target %v of type %v via API service.",
+		existing.DisplayName, existing.Type)
 	return nil
 }

--- a/pkg/client/tp_client.go
+++ b/pkg/client/tp_client.go
@@ -56,10 +56,12 @@ func (c *TPClient) AddTarget(target *api.Target) error {
 		targetName, target.Type, probeID)
 
 	// Construct the TargetSpec required by the rest api
+	inputFields, communicationBindingChannel := c.extractCommunicationBindingChannel(target.InputFields)
 	targetSpec := &api.TargetSpec{
-		ProbeID:          probeID,
-		DerivedTargetIDs: []string{},
-		InputFields:      target.InputFields,
+		ProbeID:                     probeID,
+		DerivedTargetIDs:            []string{},
+		InputFields:                 inputFields,
+		CommunicationBindingChannel: communicationBindingChannel,
 	}
 
 	// Create the rest api request
@@ -93,6 +95,22 @@ func (c *TPClient) AddTarget(target *api.Target) error {
 		targetInfo.TargetID)
 
 	return nil
+}
+
+// extractCommunicationBindingChannel iterates the list of input fields and extracts out the communication binding
+// channel into a separate attribute to return; this also returns a list of input fields with the communication binding
+// channel removed
+func (c *TPClient) extractCommunicationBindingChannel(inputFields []*api.InputField) ([]*api.InputField, string) {
+	var communicationBindingChannel string
+	var extractedInputFields []*api.InputField
+	for _, inputField := range inputFields {
+		if inputField.Name == api.COMMUNICATION_BINDING_CHANNEL {
+			communicationBindingChannel = inputField.Value
+		} else {
+			extractedInputFields = append(extractedInputFields, inputField)
+		}
+	}
+	return extractedInputFields, communicationBindingChannel
 }
 
 func (c *TPClient) findTarget(targetName string) (*api.TargetInfo, error) {

--- a/pkg/client/tp_client.go
+++ b/pkg/client/tp_client.go
@@ -104,7 +104,7 @@ func (c *TPClient) extractCommunicationBindingChannel(inputFields []*api.InputFi
 	var communicationBindingChannel string
 	var extractedInputFields []*api.InputField
 	for _, inputField := range inputFields {
-		if inputField.Name == api.COMMUNICATION_BINDING_CHANNEL {
+		if inputField.Name == api.CommunicationBindingChannel {
 			communicationBindingChannel = inputField.Value
 		} else {
 			extractedInputFields = append(extractedInputFields, inputField)

--- a/pkg/client/tp_client.go
+++ b/pkg/client/tp_client.go
@@ -30,6 +30,14 @@ func (c *TPClient) DiscoverTarget(uuid string) (*Result, error) {
 
 // AddTarget adds a target via topology processor service
 func (c *TPClient) AddTarget(target *api.Target) error {
+	glog.V(2).Infof("Getting probe ID for probe with category %v and type %v.",
+		target.Category, target.Type)
+
+	probeID, err := c.getProbeID(target.Type, target.Category)
+	if err != nil {
+		return fmt.Errorf("failed to get probe ID: %v", err)
+	}
+
 	// Check if the given target already exists
 	targetName := getTargetId(target)
 	existingTarget, err := c.findTarget(targetName)
@@ -40,15 +48,17 @@ func (c *TPClient) AddTarget(target *api.Target) error {
 	if existingTarget != nil {
 		glog.V(2).Infof("Target %v already exists with ID %v.",
 			targetName, existingTarget)
-		return c.updateTarget(existingTarget, target)
-	}
-
-	glog.V(2).Infof("Getting probe ID for probe with category %v and type %v.",
-		target.Category, target.Type)
-
-	probeID, err := c.getProbeID(target.Type, target.Category)
-	if err != nil {
-		return fmt.Errorf("failed to get probe ID: %v", err)
+		if probeID == existingTarget.TargetSpec.ProbeID {
+			return c.updateTarget(existingTarget, target)
+		}
+		glog.V(2).Infof("Delete and re-add the target to update the probe id "+
+			"(old probe id: %v, new probe id: %v, old target: %v, new target: %v of type %v)",
+			existingTarget.TargetSpec.ProbeID, probeID, existingTarget, target.DisplayName, target.Type)
+		if err := c.deleteTarget(existingTarget); err != nil {
+			return fmt.Errorf("failed to delete target %v of probe id %v which is necessary " +
+				"due to probe type changed to %v (new id %v); error: %v",
+				existingTarget.DisplayName, existingTarget.TargetSpec.ProbeID, target.Type, probeID, err)
+		}
 	}
 
 	// Add the target which belongs to the probe with the given probeID
@@ -212,7 +222,9 @@ func (c *TPClient) getProbeID(probeType, probeCategory string) (int64, error) {
 
 func (c *TPClient) updateTarget(existingTarget *api.TargetInfo, input *api.Target) error {
 	// existingTarget.TargetSpec is guaranteed to be non nil
-	existingTarget.TargetSpec.InputFields = input.InputFields
+	inputFields, communicationBindingChannel := c.extractCommunicationBindingChannel(input.InputFields)
+	existingTarget.TargetSpec.InputFields = inputFields
+	existingTarget.TargetSpec.CommunicationBindingChannel = communicationBindingChannel
 	targetData, err := json.Marshal(existingTarget.TargetSpec)
 	if err != nil {
 		return fmt.Errorf("failed to marshall input fields array: %v", err)
@@ -237,5 +249,29 @@ func (c *TPClient) updateTarget(existingTarget *api.TargetInfo, input *api.Targe
 		return buildResponseError("target update", response.status, response.body)
 	}
 	glog.V(2).Infof("Successfully updated target via Topology Processor service: %v.", existingTarget.TargetID)
+	return nil
+}
+
+// deleteTarget deletes an existing target
+func (c *TPClient) deleteTarget(existingTarget *api.TargetInfo) error {
+	// Create the rest api request
+	request := c.Delete().Resource(api.Resource_Type_Target).Name(strconv.FormatInt(existingTarget.TargetID, 10)).
+		Header("Content-Type", "application/json").
+		Header("Accept", "application/json")
+
+	glog.V(4).Infof("[DeleteTarget] %v", request)
+
+	// Execute the request
+	response, err := request.Do()
+	if err != nil {
+		return fmt.Errorf("request %v failed: %s", request, err)
+	}
+	glog.V(4).Infof("Response %+v", response)
+
+	if response.statusCode != 200 {
+		return buildResponseError("target delete", response.status, response.body)
+	}
+	glog.V(2).Infof("Successfully deleted target %v of probe id %v via Topology Processor service.",
+		existingTarget.DisplayName, existingTarget.TargetSpec.ProbeID)
 	return nil
 }

--- a/pkg/client/tp_client.go
+++ b/pkg/client/tp_client.go
@@ -55,7 +55,7 @@ func (c *TPClient) AddTarget(target *api.Target) error {
 			"(old probe id: %v, new probe id: %v, old target: %v, new target: %v of type %v)",
 			existingTarget.TargetSpec.ProbeID, probeID, existingTarget, target.DisplayName, target.Type)
 		if err := c.deleteTarget(existingTarget); err != nil {
-			return fmt.Errorf("failed to delete target %v of probe id %v which is necessary " +
+			return fmt.Errorf("failed to delete target %v of probe id %v which is necessary "+
 				"due to probe type changed to %v (new id %v); error: %v",
 				existingTarget.DisplayName, existingTarget.TargetSpec.ProbeID, target.Type, probeID, err)
 		}

--- a/pkg/client/tp_client_test.go
+++ b/pkg/client/tp_client_test.go
@@ -4,8 +4,10 @@ import (
 	"crypto/tls"
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	"github.com/turbonomic/turbo-api/pkg/api"
 	"net/http"
 	"net/url"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -23,4 +25,29 @@ func TestGetProbeIDWithRetry(t *testing.T) {
 	assert.Error(t, err)
 	assert.True(t, time.Since(start).Seconds() >= float64(retryAttempts-1)*retryDelay.Seconds())
 	fmt.Println(err)
+}
+
+func TestExtractCommunicationBindingChannel(t *testing.T) {
+	communicationBindingChannel := "xoxo"
+	inputField1 := api.InputField{Name: "foo", Value: "123"}
+	inputField2 := api.InputField{Name: api.COMMUNICATION_BINDING_CHANNEL, Value: communicationBindingChannel}
+	inputField3 := api.InputField{Name: "bar", Value: "456"}
+	inputFields := []*api.InputField{&inputField1, &inputField2, &inputField3}
+	expectedInputFields := []*api.InputField{&inputField1, &inputField3}
+
+	tpClient := TPClient{}
+	// with all 3 fields as input
+	extractedInputFields, extractedChannel := tpClient.extractCommunicationBindingChannel(inputFields)
+	assert.Equalf(t, communicationBindingChannel, extractedChannel,
+		"Actual extracted communication binding channel %v is different than the expected %v", extractedChannel,
+		communicationBindingChannel)
+	assert.True(t, reflect.DeepEqual(expectedInputFields, extractedInputFields), "Expected input fields: %v," +
+		" are not the same as the actual: %v", expectedInputFields, extractedInputFields)
+
+	// with only field 1 and field 3
+	extractedInputFields, extractedChannel = tpClient.extractCommunicationBindingChannel(expectedInputFields)
+	assert.Equalf(t, "", extractedChannel,
+		"Actual extracted communication binding channel %v should be an empty string but not", extractedChannel)
+	assert.True(t, reflect.DeepEqual(expectedInputFields, extractedInputFields), "Expected input fields: %v," +
+		" are not the same as the actual: %v", expectedInputFields, extractedInputFields)
 }

--- a/pkg/client/tp_client_test.go
+++ b/pkg/client/tp_client_test.go
@@ -41,13 +41,13 @@ func TestExtractCommunicationBindingChannel(t *testing.T) {
 	assert.Equalf(t, communicationBindingChannel, extractedChannel,
 		"Actual extracted communication binding channel %v is different than the expected %v", extractedChannel,
 		communicationBindingChannel)
-	assert.True(t, reflect.DeepEqual(expectedInputFields, extractedInputFields), "Expected input fields: %v," +
+	assert.True(t, reflect.DeepEqual(expectedInputFields, extractedInputFields), "Expected input fields: %v,"+
 		" are not the same as the actual: %v", expectedInputFields, extractedInputFields)
 
 	// with only field 1 and field 3
 	extractedInputFields, extractedChannel = tpClient.extractCommunicationBindingChannel(expectedInputFields)
 	assert.Equalf(t, "", extractedChannel,
 		"Actual extracted communication binding channel %v should be an empty string but not", extractedChannel)
-	assert.True(t, reflect.DeepEqual(expectedInputFields, extractedInputFields), "Expected input fields: %v," +
+	assert.True(t, reflect.DeepEqual(expectedInputFields, extractedInputFields), "Expected input fields: %v,"+
 		" are not the same as the actual: %v", expectedInputFields, extractedInputFields)
 }

--- a/pkg/client/tp_client_test.go
+++ b/pkg/client/tp_client_test.go
@@ -30,7 +30,7 @@ func TestGetProbeIDWithRetry(t *testing.T) {
 func TestExtractCommunicationBindingChannel(t *testing.T) {
 	communicationBindingChannel := "xoxo"
 	inputField1 := api.InputField{Name: "foo", Value: "123"}
-	inputField2 := api.InputField{Name: api.COMMUNICATION_BINDING_CHANNEL, Value: communicationBindingChannel}
+	inputField2 := api.InputField{Name: api.CommunicationBindingChannel, Value: communicationBindingChannel}
 	inputField3 := api.InputField{Name: "bar", Value: "456"}
 	inputFields := []*api.InputField{&inputField1, &inputField2, &inputField3}
 	expectedInputFields := []*api.InputField{&inputField1, &inputField3}


### PR DESCRIPTION
Enhanced the turbo-api client to support injecting the communication binding channel so to leverage the capability to bind the target with the probe.  This also means that we could get rid of the target type suffix which was the old way of sticking the target with the probe.

**Overall solution**
- If the target type is configured, then that will be used as the probe type suffix; this is the current behavior.
- If the target type is not configured, then a normalized probe type will be used (e.g. "Kubernetes" for kubeturbo probe); this is a new behavior.
Please see a more detailed summary below:
<img width="1101" alt="kubeturbo-binding-channel" src="https://user-images.githubusercontent.com/6045065/115904327-a6e0c300-a432-11eb-841d-e7ac35960ae6.png">

This is translated to the following adjustment to the turbo-api to support upgrading probes when the target type isn't configured:
- If the probe type is different, then the target will be deleted and re-added using the new probe type.

**Functions added**
- delete target functions in both api_client and tp_client, for changing the probe type the target will have to be deleted and re-added.
- extract the communication binding channel from the target input fields, which is needed because the add target body is different between the api and the topology processor APIs and a conversion is required.
- Also relaxing the matching condition in the api_client's findTarget() method so we can still find the old target even the probe type has changed.

**Tests done** (with corresponding changes in [turbo-go-sdk](https://github.com/turbonomic/turbo-go-sdk/pull/120) and [kubeturbo](https://github.com/turbonomic/kubeturbo/pull/549)):
- Tested adding a new target using the binding channel method
- Tested upgrade scenarios with different combinations of target type, target name and whether credentials are specified; please see the attached screenshot
<img width="895" alt="kubeturbo-binding-channel-test-scenarios" src="https://user-images.githubusercontent.com/6045065/115904430-c11aa100-a432-11eb-8ca1-a27768f1d73a.png">
- Tested triggering discovery requests on one of the targets with the normalized probe type, and ensured that the request only went to the specific probe/cluster to prove that the binding channel method is working.
- Triggered discoveries multiple times on the same target and confirmed they all went to the same probe.
