### PR TITLE
[OM-85107]: Add Hydra and Auth API support for getting the jwtToken for secure probe registration

### DIFF
--- a/pkg/api/resource_type.go
+++ b/pkg/api/resource_type.go
@@ -8,4 +8,6 @@ const (
 	Resource_Type_Target          ResourceType = "target"
 	Resource_Type_Probe           ResourceType = "probe"
 	Resource_Type_External_Target ResourceType = "externaltargets"
+	Resource_Type_hydra_token     ResourceType = "token"
+	Resource_Type_auth_token      ResourceType = "exchange"
 )

--- a/pkg/client/api_client.go
+++ b/pkg/client/api_client.go
@@ -1,10 +1,12 @@
 package client
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"github.com/golang/glog"
 	"github.com/turbonomic/turbo-api/pkg/api"
+	"mime/multipart"
 	"net/http"
 	"strings"
 )
@@ -13,11 +15,63 @@ import (
 type APIClient struct {
 	*RESTClient
 	SessionCookie *http.Cookie
+	ClientId string
+	ClientSecret string
 }
 
 const (
 	SessionCookie string = "JSESSIONID"
 )
+
+type HydraTokenBody struct {
+	AccessToken string `json:"access_token,omitempty"`
+	ExpiresIn   int    `json:"expires_in,omitempty"`
+	Scope       string `json:"scope,omitempty"`
+	TokenType   string `json:"token_type,omitempty"`
+}
+func (c *APIClient) GetJwtToken(hydraToken string) (string, error) {
+	if hydraToken == "" {
+		glog.V(4).Infof("The hydra token is empty")
+		return "", nil
+	}
+	request := c.Post().Resource(api.Resource_Type_auth_token).Header("x-oauth2", "hydra").Header("x-auth-token", hydraToken)
+	// Execute the request
+	response, err := request.Do()
+	if err != nil {
+		return "", fmt.Errorf("request %v failed: %s", request, err)
+	}
+	return response.body, nil
+}
+
+func (c *APIClient) GetHydraAccessToken() (string, error) {
+	if c.ClientId == "" || c.ClientSecret == "" {
+		glog.V(4).Infof("The client id or client secret are not provided")
+		return "", nil
+	}
+
+	payload := &bytes.Buffer{}
+	writer := multipart.NewWriter(payload)
+	_ = writer.WriteField("client_id", c.ClientId)
+	_ = writer.WriteField("client_secret", c.ClientSecret)
+	_ = writer.WriteField("grant_type", "client_credentials")
+	err := writer.Close()
+	if err != nil {
+		return "", fmt.Errorf("failed to Close the writer: %v", err)
+	}
+	// Create the rest api request
+	request := c.Post().Resource(api.Resource_Type_hydra_token).Header("Content-Type", writer.FormDataContentType()).BufferData(payload)
+	// Execute the request
+	response, err := request.Do()
+	if err != nil {
+		return "", fmt.Errorf("request %v failed: %s", request, err)
+	}
+	var hydraToken HydraTokenBody
+	err = json.Unmarshal([]byte(response.body), &hydraToken)
+	if err != nil {
+		return "", fmt.Errorf("Unmarshall Token failed: %s", request, err)
+	}
+	return hydraToken.AccessToken, nil
+}
 
 // Discover a target using API
 // This function is called by turboctl which is not being maintained

--- a/pkg/client/api_client.go
+++ b/pkg/client/api_client.go
@@ -15,8 +15,8 @@ import (
 type APIClient struct {
 	*RESTClient
 	SessionCookie *http.Cookie
-	ClientId string
-	ClientSecret string
+	ClientId      string
+	ClientSecret  string
 }
 
 const (
@@ -29,6 +29,7 @@ type HydraTokenBody struct {
 	Scope       string `json:"scope,omitempty"`
 	TokenType   string `json:"token_type,omitempty"`
 }
+
 func (c *APIClient) GetJwtToken(hydraToken string) (string, error) {
 	if hydraToken == "" {
 		glog.V(4).Infof("The hydra token is empty")

--- a/pkg/client/api_client.go
+++ b/pkg/client/api_client.go
@@ -69,7 +69,7 @@ func (c *APIClient) GetHydraAccessToken() (string, error) {
 	var hydraToken HydraTokenBody
 	err = json.Unmarshal([]byte(response.body), &hydraToken)
 	if err != nil {
-		return "", fmt.Errorf("Unmarshall Token failed: %s", request, err)
+		return "", fmt.Errorf("failed to unmarshall get hydra token response: %v", err)
 	}
 	return hydraToken.AccessToken, nil
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -21,25 +21,25 @@ func TestNewTurboClient(t *testing.T) {
 		expectedClient Client
 	}{
 		{
-			config:  &Config{baseURL, &BasicAuthentication{"foo", "bar"}, ""},
+			config:  &Config{baseURL, &BasicAuthentication{"foo", "bar"}, "", "", ""},
 			service: API,
 			expectedClient: &APIClient{
 				&RESTClient{http.DefaultClient, baseURL, APIPath, &BasicAuthentication{"foo", "bar"}},
-				nil,
+				nil, "", "",
 			},
 		},
 		{
-			config:  &Config{secureURL, &BasicAuthentication{"foo", "bar"}, ""},
+			config:  &Config{secureURL, &BasicAuthentication{"foo", "bar"}, "", "", ""},
 			service: API,
 			expectedClient: &APIClient{
 				&RESTClient{&http.Client{Transport: &http.Transport{
 					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 				}}, secureURL, APIPath, &BasicAuthentication{"foo", "bar"}},
-				nil,
+				nil, "", "",
 			},
 		},
 		{
-			config:  &Config{secureURL, nil, ""},
+			config:  &Config{secureURL, nil, "", "", ""},
 			service: TopologyProcessor,
 			expectedClient: &TPClient{
 				&RESTClient{&http.Client{Transport: &http.Transport{
@@ -67,7 +67,7 @@ func TestNewTurboClient(t *testing.T) {
 func TestClient_DiscoverTarget_WithError(t *testing.T) {
 	uuid := ""
 	baseURL, _ := url.Parse("http://localhost")
-	config := &Config{baseURL, &BasicAuthentication{"foo", "bar"}, ""}
+	config := &Config{baseURL, &BasicAuthentication{"foo", "bar"}, "", "", ""}
 	turboClient, _ := NewTurboClient(config)
 	_, err := turboClient.DiscoverTarget(uuid, API)
 	if err == nil {
@@ -78,7 +78,7 @@ func TestClient_DiscoverTarget_WithError(t *testing.T) {
 func TestClient_AddTarget_WithError(t *testing.T) {
 	target := &api.Target{}
 	baseURL, _ := url.Parse("http://localhost")
-	config := &Config{baseURL, &BasicAuthentication{"foo", "bar"}, ""}
+	config := &Config{baseURL, &BasicAuthentication{"foo", "bar"}, "", "", ""}
 	turboClient, _ := NewTurboClient(config)
 	if err := turboClient.AddTarget(target, API); err == nil {
 		t.Error("Expected error, but got no error.")

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -10,13 +10,17 @@ type Config struct {
 	// For Basic authentication.
 	basicAuth *BasicAuthentication
 	// For proxy
-	proxy string
+	proxy        string
+	clientId     string
+	clientSecret string
 }
 
 type ConfigBuilder struct {
 	serverAddress *url.URL
 	basicAuth     *BasicAuthentication
 	proxy         string
+	clientId      string
+	clientSecret  string
 }
 
 func NewConfigBuilder(serverAddress *url.URL) *ConfigBuilder {
@@ -27,6 +31,16 @@ func NewConfigBuilder(serverAddress *url.URL) *ConfigBuilder {
 
 func (cb *ConfigBuilder) SetProxy(proxy string) *ConfigBuilder {
 	cb.proxy = proxy
+	return cb
+}
+
+func (cb *ConfigBuilder) SetClientId(clientId string) *ConfigBuilder {
+	cb.clientId = clientId
+	return cb
+}
+
+func (cb *ConfigBuilder) SetClientSecret(clientSecret string) *ConfigBuilder {
+	cb.clientSecret = clientSecret
 	return cb
 }
 
@@ -43,5 +57,7 @@ func (cb *ConfigBuilder) Create() *Config {
 		serverAddress: cb.serverAddress,
 		basicAuth:     cb.basicAuth,
 		proxy:         cb.proxy,
+		clientId:      cb.clientId,
+		clientSecret:  cb.clientSecret,
 	}
 }

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -63,11 +63,11 @@ func TestConfigBuilder_Create(t *testing.T) {
 			serverAddress:  baseURL,
 			username:       "foo",
 			password:       "bar",
-			expectedConfig: &Config{baseURL, &BasicAuthentication{"foo", "bar"}, ""},
+			expectedConfig: &Config{baseURL, &BasicAuthentication{"foo", "bar"}, "", "", ""},
 		},
 		{
 			serverAddress:  baseURL,
-			expectedConfig: &Config{baseURL, nil, ""},
+			expectedConfig: &Config{baseURL, nil, "", "", ""},
 		},
 	}
 	for _, item := range table {

--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -123,6 +123,11 @@ func (r *Request) Data(data []byte) *Request {
 	return r
 }
 
+func (r *Request) BufferData(data *bytes.Buffer) *Request {
+	r.data = data
+	return r
+}
+
 // URL returns the current working URL.
 func (r *Request) URL() *url.URL {
 	p := r.pathPrefix

--- a/pkg/client/tp_client.go
+++ b/pkg/client/tp_client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/enlinxu/turbo-api/vendor/github.com/avast/retry-go"
 	"strconv"
 	"time"
 
@@ -23,11 +24,11 @@ type TPClient struct {
 }
 
 func (c *TPClient) GetJwtToken(hydraToken string) (string, error) {
-	panic("implement me")
+	panic("the program is trying to get jwtToken from TP Client, which should never happen")
 }
 
 func (c *TPClient) GetHydraAccessToken() (string, error) {
-	panic("implement me")
+	panic("the program is trying to get hydra access token from TP Client, which should never happen")
 }
 
 // DiscoverTarget adds a target via Topology Processor service

--- a/pkg/client/tp_client.go
+++ b/pkg/client/tp_client.go
@@ -22,6 +22,14 @@ type TPClient struct {
 	*RESTClient
 }
 
+func (c *TPClient) GetJwtToken(hydraToken string) (string, error) {
+	panic("implement me")
+}
+
+func (c *TPClient) GetHydraAccessToken() (string, error) {
+	panic("implement me")
+}
+
 // DiscoverTarget adds a target via Topology Processor service
 func (c *TPClient) DiscoverTarget(uuid string) (*Result, error) {
 	// Not implemented

--- a/pkg/client/tp_client.go
+++ b/pkg/client/tp_client.go
@@ -3,7 +3,6 @@ package client
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/enlinxu/turbo-api/vendor/github.com/avast/retry-go"
 	"strconv"
 	"time"
 


### PR DESCRIPTION
*** Intent
For secure probe registration, we now need to acquire the jwtToken in the header of websocket connection. The review includes the changes to acquire Hydra access token from https://<Server>/vmturbo/hydra/token, and then jwtToken from https://<Server>/vmturbo/auth/exchange

*** Implementation
This review only includes the change for API. More changes in Turbo go SDK and Kubeturbo. The flow is the following:
1. Kubeturbo load clientid and clientsecret from k8s secret
2. In Turbo Go SDK, clientid and clientsecret are parsed to APIClient during the creation of the client
3. GetHydraToken and GetJwtToken are invoked before the websocket connection.
4. 
*** Test
Use the secure probe enabled server and check the probe registration.
![Screen Shot 2022-05-31 at 5 17 05 PM](https://user-images.githubusercontent.com/4391815/171779371-cbda4837-cbec-47bc-adca-4f4fc6877ff4.png)

To create the secret with the client id and client secret
➜ 25secure echo -n 'my-client25' | openssl base64
bXktY2xpZW50MjU=

➜ 25secure echo -n 'secret25' | openssl base64
c2VjcmV0MjU=

➜ 25secure cat secret
apiVersion: v1
kind: Secret
metadata:
name: turbonomic-credentials-secure
namespace: turbo
type: Opaque
data:
username: dGVzdC11c2Vy
password: dGVzdHBhc3N3ZA==
clientid: bXktY2xpZW50MjU=
clientsecret: c2VjcmV0MjU=