### PR TITLE
[OM-90183]: Log errors when the hydra and auth service cannot authenticate or are down

### DIFF
--- a/pkg/client/api_client.go
+++ b/pkg/client/api_client.go
@@ -83,7 +83,7 @@ func (c *APIClient) GetHydraAccessToken() (string, error) {
 		// When we receive the 401 status code, means that the credentials are not valid.
 		// We return error, so getJwtToken() method in tap_service will continue
 		// to retry authentication until the credentials are corrected
-		return "",  fmt.Errorf("Hydra service authentication failed using the given client_id and secret")
+		return "", fmt.Errorf("Hydra service authentication failed using the given client_id and secret")
 	}
 	if response.statusCode == 403 || response.statusCode == 502 {
 		// When we receive the 403 status code, meaning the hydra service is currently not available.

--- a/pkg/client/api_client.go
+++ b/pkg/client/api_client.go
@@ -42,7 +42,13 @@ func (c *APIClient) GetJwtToken(hydraToken string) (string, error) {
 	// Execute the request
 	response, err := request.Do()
 	if err != nil {
-		return "", fmt.Errorf("request %v failed: %s", request, err)
+		return "", fmt.Errorf("request to exchange for auth token %v failed: %s", request, err)
+	}
+	if response.statusCode == 502 || response.statusCode == 403 {
+		// When we receive the 502 or 403 status code, meaning the auth service is currently not available.
+		// We will retry websocket connection without the JWTToken
+		glog.Errorf("Auth service is not accessible or disabled [%v:%s]", response.statusCode, response.status)
+		return "", nil
 	}
 	return response.body, nil
 }
@@ -73,12 +79,18 @@ func (c *APIClient) GetHydraAccessToken() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get hydra access token: %s", err)
 	}
-	if response.statusCode == 403 {
+	if response.statusCode == 401 {
+		// When we receive the 401 status code, means that the credentials are not valid.
+		// We return error, so getJwtToken() method in tap_service will continue
+		// to retry authentication until the credentials are corrected
+		return "",  fmt.Errorf("Hydra service authentication failed using the given client_id and secret")
+	}
+	if response.statusCode == 403 || response.statusCode == 502 {
 		// When we receive the 403 status code, meaning the hydra service is currently not available.
 		// We are not returning error here to handle the case when customer enabled probe security in the first place then disabled
 		// In the case above, there'll be client_id and secret in the k8s secret, but we shouldn't use them in websocket connection
 		// If the hydra service is temporarily not accessible, we have retry in performWebSocketConnection in turbo-go-sdk
-		glog.Errorf("Hydra service is not accessible or disabled")
+		glog.Errorf("Hydra service is not accessible or disabled [%v:%s]", response.statusCode, response.status)
 		return "", nil
 	}
 	var hydraToken HydraTokenBody


### PR DESCRIPTION
We want to log the real cause of not establishing the connection with the server. Server can run in secure and non-secure mode.
In secure mode - 
- communication errors happen when a required pod is down or network problems occur
- authentication errors occur when client id/secret credentials are incorrect

In non-secure mode - probe should attempt connection on a non-secure web socket.

### TESTING
### Non-secure server
* **Probe did not sent any client/secret**
    * Hydra pod UP 
             Hydra request is NOT sent -> attempt to connect without JWToken -> SUCCESS
    * Hydra pod DOWN 
             Hydra request is NOT sent -> attempt to connect without JWToken -> SUCCESS

* **Probe sent client id/secret**
    * **Hydra pod UP** 
           Send Hydra request -> Hydra service not available  (403) ->  Auth request is not sent -> attempt to connect without JWToken -> SUCCESS
    * **Hydra pod DOWN** 
            Hydra request is sent -> Hydra service not available (403) -> Auth request is not sent -> attempt to connect without JWToken -> SUCCESS

* **Probe sent wrong client id/secret**
    * **Hydra pod UP** 
             Send Hydra request -> Hydra service not available  (403) ->  Auth request is not sent -> attempt to connect without JWToken -> SUCCESS
    * **Hydra pod DOWN** 
            Hydra request is sent -> Hydra service not available (403) -> Auth request is not sent -> attempt to connect without JWToken -> SUCCESS

### Secure server (strict) + Hydra pod enabled
* **Probe did not sent any client/secret**
  Hydra request is NOT sent -> attempt to connect without JWToken -> hit the no-token clause in SprintTpFilter -> ERROR

* **Probe sent client id/secret**
    * **Hydra service is UP**
             Send Hydra request -> Hydra token is valid (402)  ->  Auth request is sent -> Auth token is valid -> attempt to connect with JWToken -> SUCCESS
    * **Hydra service is DOWN**
             Send Hydra request -> Hydra comp is down (502) ->  Auth request is not sent -> attempt to connect without JWToken -> ERROR
    * **AUTH Comp Down** 
             Send Hydra request -> Hydra token is valid (402) ->  Send Auth request  -> Auth comp is down (502) -> attempt to connect without JWToken -> ERROR
    * **NGINX Comp Down**
             Send Hydra request -> Error : cannot connect ->  Retry sending Request until successful   -> No attempt to  establish web socket connection -> ERROR

* **Probe sent wrong client id/secret**
    * **Hydra service is UP**
          Send Hydra request -> Hydra token is invalid (401) ->   Retry until authentication is successful   -> No attempt to establish web socket connection -> ERROR
