### PR TITLE
[OM-90183]: Distinguish between the 403 and 502 error response from the Hydra service

### DIFF
--- a/pkg/client/api_client.go
+++ b/pkg/client/api_client.go
@@ -56,7 +56,7 @@ func (c *APIClient) GetJwtToken(hydraToken string) (string, error) {
 		glog.Errorf("Auth service is not accessible or disabled [%v:%s]", response.statusCode, response.status)
 		return "", nil
 	}
-	if response.statusCode == 502  {
+	if response.statusCode == 502 {
 		// When we receive the 502 status code, meaning the auth service is currently not available.
 		// We return error, so getJwtToken() method in tap_service will continue
 		// to retry authentication until the service is restored

--- a/pkg/client/api_client.go
+++ b/pkg/client/api_client.go
@@ -44,11 +44,23 @@ func (c *APIClient) GetJwtToken(hydraToken string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("request to exchange for auth token %v failed: %s", request, err)
 	}
-	if response.statusCode == 502 || response.statusCode == 403 {
-		// When we receive the 502 or 403 status code, meaning the auth service is currently not available.
+	if response.statusCode == 401 {
+		// When we receive the 401 status code, means that the credentials are not valid.
+		// We return error, so getJwtToken() method in tap_service will continue
+		// to retry authentication until the credentials are corrected
+		return "", fmt.Errorf("Auth service authentication failed using the given client_id and secret")
+	}
+	if response.statusCode == 403 {
+		// When we receive the 403 status code, meaning the security feature is currently not available.
 		// We will retry websocket connection without the JWTToken
 		glog.Errorf("Auth service is not accessible or disabled [%v:%s]", response.statusCode, response.status)
 		return "", nil
+	}
+	if response.statusCode == 502  {
+		// When we receive the 502 status code, meaning the auth service is currently not available.
+		// We return error, so getJwtToken() method in tap_service will continue
+		// to retry authentication until the service is restored
+		return "", fmt.Errorf("Auth service is not available [%v:%s]", response.statusCode, response.status)
 	}
 	return response.body, nil
 }
@@ -85,8 +97,15 @@ func (c *APIClient) GetHydraAccessToken() (string, error) {
 		// to retry authentication until the credentials are corrected
 		return "", fmt.Errorf("Hydra service authentication failed using the given client_id and secret")
 	}
-	if response.statusCode == 403 || response.statusCode == 502 {
-		// When we receive the 403 status code, meaning the hydra service is currently not available.
+	if response.statusCode == 502 {
+		// When we receive the 502 status code, meaning the hydra service is currently not available.
+		// We return error, so getJwtToken() method in tap_service will continue
+		// to retry authentication until the service is restored
+		return "", fmt.Errorf("Hydra service is not available [%v:%s]", response.statusCode, response.status)
+	}
+	if response.statusCode == 403 {
+		// When we receive the 403 status code, means that the hydra service is currently not available,
+		// This is when the security feature is not available.
 		// We are not returning error here to handle the case when customer enabled probe security in the first place then disabled
 		// In the case above, there'll be client_id and secret in the k8s secret, but we shouldn't use them in websocket connection
 		// If the hydra service is temporarily not accessible, we have retry in performWebSocketConnection in turbo-go-sdk


### PR DESCRIPTION
For better logging and debugging, made changes to distinguish between the 403/502 error response from the Hydra service.

- 403 is returned when the secure feature is not available in the server and the hydra service is not made accessible to remote probes. This is irrespective of whether the hydra pod is up or down.

When the turbo-api receives this response, it will not return error, the `TAPService (turbo-go-sdk)` will then connect on the non-secure web socket.

**When server is running in non-secure mode and Hydra pod is UP/Down:**
<img width="1229" alt="Screen Shot 2022-10-10 at 1 48 07 PM" src="https://user-images.githubusercontent.com/11964436/194931780-3efb98a8-779a-4c8d-9f36-b5c0bb7a17d8.png">


- 502 is returned when the Hydra pod is down. This is when the server is running in secure mode and the hydra pod is down.

When the turbo-api receives this response, it will return error, so the `TAPService (turbo-go-sdk)` will continue to retry connecting to the authentication services until the service is restored.

**When server is running in secure mode and the Hydra pod is down:**
<img width="1211" alt="Screen Shot 2022-10-10 at 2 18 12 PM" src="https://user-images.githubusercontent.com/11964436/194931822-2347d932-c348-4f51-9494-c30020bf21c4.png">


**When server is running in secure mode and the Auth pod is down:**
<img width="1206" alt="Screen Shot 2022-10-10 at 2 22 42 PM" src="https://user-images.githubusercontent.com/11964436/194931839-35bf17de-db55-47b8-bc82-c8e593d36b43.png">

