### PR TITLE
[OM-90183]: Modified the error message when the hydra service credentials are wrong

### DIFF
--- a/pkg/client/api_client.go
+++ b/pkg/client/api_client.go
@@ -95,7 +95,8 @@ func (c *APIClient) GetHydraAccessToken() (string, error) {
 		// When we receive the 401 status code, means that the credentials are not valid.
 		// We return error, so getJwtToken() method in tap_service will continue
 		// to retry authentication until the credentials are corrected
-		return "", fmt.Errorf("Hydra service authentication failed using the given client_id and secret")
+		return "", fmt.Errorf("Hydra service authentication failed using the given client_id and secret. " +
+			"Redeploy the secret containing the correct credentials and restart the probe pod")
 	}
 	if response.statusCode == 502 {
 		// When we receive the 502 status code, meaning the hydra service is currently not available.


### PR DESCRIPTION
In order to indicate to the probe users , how to handle the situation when the credentials for the Hydra service are wrong, modified the error message as shown in the screen shot.


<img width="1227" alt="Screen Shot 2022-10-10 at 5 55 42 PM" src="https://user-images.githubusercontent.com/11964436/194958635-4cbf984b-34da-4983-901f-519dbb1b1ecf.png">

