### PR TITLE
[TRB-46810]: Removed coveralls integration from travis build. Removed coverage badge from README.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ go:
 
 go_import_path: github.com/turbonomic/turbo-api
 
-before_install:
-  - go get -v github.com/mattn/goveralls
-
 script:
   - make fmtcheck
-  - $HOME/gopath/bin/goveralls -v -race -service=travis-ci -ignore="example/*"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: go
 
 go:
-  - 1.16
+  - 1.20.7
 
 go_import_path: github.com/turbonomic/turbo-api
 
 script:
   - make fmtcheck
+  - make test
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # turbo-api
 
 [![Build Status](https://travis-ci.org/turbonomic/turbo-api.svg?branch=master)](https://travis-ci.org/turbonomic/turbo-api)
-[![Coverage Status](https://coveralls.io/repos/github/turbonomic/turbo-api/badge.svg?branch=master)](https://coveralls.io/github/turbonomic/turbo-api?branch=master)
 
 Go API client for Turbonomic


### PR DESCRIPTION
# Intent

Remove coveralls integrations from Travis builds.

# Background

Coveralls is free for public repositories, but requires licenses for private/enterprise repos. Since we are moving to IBM enterprise Git, we need to remove this integration. We should be able to capture code coverage using SonarQube, or some other approved, tool in the future. 

# Testing

N/A - will test enterprise build after merging.