### PR TITLE
[TRB46642]: refactoring hydra endpoint

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -17,7 +17,7 @@ var (
 	AUTH                  = "auth"
 	APIPath               = "/vmturbo/rest/"
 	TopologyProcessorPath = "/"
-	HydraPath             = "/vmturbo/hydra/"
+	HydraPath             = "/oauth2/"
 	AuthPath              = "/vmturbo/auth/"
 
 	defaultRESTAPIEndpoints = map[string]string{


### PR DESCRIPTION
# Intent

Refactor the existing (redunant) path that points to our underlying Hydra server

# Background

- We should not specify the name hydra in the public API as that exposes the implementation (which may well change)
- There is no 'standard' path, but both Hydra and AWS use `/oauth2/token`; I suggest we follow suit.

1. Hydra: `/oauth2/token/`
2. AWS: `/oauth2/token/`
3. GCP: `/oauth2.googleapis.com/token/`
4. Facebook: `/oauth/access_token/`

# Testing

N/A - this code is currently not called as the OAuth2 service is not currently part of the Turbo product.

# Checklist

These are the items that must be done by the developer and by reviewers before the change is ready to merge. Please ~~strikeout~~ any items that are not applicable, but don't delete them

- [ ] Developer Checks
    - [ ] Full build with unit tests and fmt and vet checks
    - [ ] Unit tests added / updated
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Integration tests added / updated
    - [ ] Manual testing done (and described)
    - [ ] Product sweep run and passed
    - [ ] Developer wiki updated (and linked to this description)
- [ ] Reviewer Checks
    - [ ] Merge request description clear and understandable
    - [ ] Developer checklist items complete
    - [ ] Functional code review (how is the code written)
    - [ ] Architectural review (does the code try to do the right thing, in the right way)
    - [ ] Defensive coding (incoming data checked / sanitized, exceptions logged, clear error messages)
    - [ ] No unlicensed images, no third-party code (such as from StackOverflow)
    - [ ] Security review checklist complete.

# Audience